### PR TITLE
add create system conflict response

### DIFF
--- a/pkg/managerapi/server/rest/system.go
+++ b/pkg/managerapi/server/rest/system.go
@@ -33,13 +33,7 @@ func (r *restServer) mountSystemHandlers() {
 
 			system, err := r.backend.CreateSystem(req.ID, req.DefinitionURL)
 			if err != nil {
-				handleInternalError(c, err)
-				return
-			}
-
-			if err != nil {
-				handleInternalError(c, err)
-				return
+				handleCreateSystemError(c, err)
 			}
 
 			c.JSON(http.StatusOK, system)
@@ -97,6 +91,14 @@ func (r *restServer) mountSystemHandlers() {
 	r.mountSystemTeardownHandlers()
 	r.mountSystemServiceHandlers()
 	r.mountSystemSecretHandlers()
+}
+
+func handleCreateSystemError(c *gin.Context, err error) {
+	if strings.Contains(err.Error(), "already exists") {
+		c.Status(http.StatusConflict)
+	}
+
+	handleInternalError(c, err)
 }
 
 type systemVersionResponse struct {


### PR DESCRIPTION
untested but simple way of responding with a 409 if a system with that name already exists, informative for api

error would be specific to kubernetes backend https://github.com/mlab-lattice/system/blob/6097e58f404a478133607275a92436f9d8fc1aaf/pkg/backend/kubernetes/managerapi/server/backend/system.go#L25