### PR TITLE
Pass pointer to unmarshall when listing teardowns

### DIFF
--- a/pkg/api/client/rest/v1/teardown.go
+++ b/pkg/api/client/rest/v1/teardown.go
@@ -50,7 +50,7 @@ func (c *TeardownClient) List() ([]v1.Teardown, error) {
 
 	if statusCode == http.StatusOK {
 		var teardowns []v1.Teardown
-		err = rest.UnmarshalBodyJSON(body, teardowns)
+		err = rest.UnmarshalBodyJSON(body, &teardowns)
 		return teardowns, err
 	}
 


### PR DESCRIPTION
This was causing an error when running `systems:teardowns`