### PR TITLE
fix command line arguments passed to dns-controller

### DIFF
--- a/pkg/backend/kubernetes/cloudprovider/local/lattice_bootstrapper.go
+++ b/pkg/backend/kubernetes/cloudprovider/local/lattice_bootstrapper.go
@@ -209,6 +209,7 @@ func (cp *DefaultLocalLatticeBootstrapper) bootstrapLatticeDNS(resources *bootst
 	controllerArgs := []string{
 		"--namespace-prefix", cp.NamespacePrefix,
 		"--internal-dns-domain", cp.InternalDNSDomain,
+		"--lattice-id", string(cp.LatticeID),
 	}
 	controllerArgs = append(controllerArgs, cp.DNS.ControllerArgs...)
 	controllerArgs = append(controllerArgs, serviceMeshVars...)


### PR DESCRIPTION
lattice-id is required but was not being passed