### PR TITLE
Help template patch

### DIFF
--- a/pkg/util/cli/command.go
+++ b/pkg/util/cli/command.go
@@ -22,6 +22,7 @@ type Command struct {
 	Subcommands      []*Command
 	UsageFunc        func(*Command) error
 	HelpFunc         func(*Command)
+	FlattenUsageTree bool
 	cobraCmd         *cobra.Command
 	isSpaceSeparated bool
 }
@@ -106,14 +107,20 @@ func (c *Command) helpFuncWrapper(*cobra.Command, []string) {
 func (c *Command) defaultUsageFunc(*Command) error {
 	// TODO :: Seems like Usage & Help have the same use for us right now. (Perhaps just for default)
 	tmplName := template.DefaultTemplate
-	templateToExecute := template.DefaultUsageTemplate
+	templateToExecute := template.DefaultUsageTemplateGrouped
+	if c.FlattenUsageTree {
+		templateToExecute = template.DefaultUsageTemplate
+	}
 	return template.TryExecuteTemplate(tmplName, template.DefaultTemplate, templateToExecute, template.DefaultTemplateFuncs, c)
 }
 
 // defaultHelpFunc is the Help function that will be called if none is provided
 func (c *Command) defaultHelpFunc(*Command) {
 	tmplName := template.DefaultTemplate
-	templateToExecute := template.DefaultHelpTemplate
+	templateToExecute := template.DefaultHelpTemplateGrouped
+	if c.FlattenUsageTree {
+		templateToExecute = template.DefaultHelpTemplate
+	}
 	err := template.TryExecuteTemplate(tmplName, template.DefaultTemplate, templateToExecute, template.DefaultTemplateFuncs, c)
 	if err != nil {
 		log.Fatalf(err.Error())

--- a/pkg/util/cli/command.go
+++ b/pkg/util/cli/command.go
@@ -22,7 +22,7 @@ type Command struct {
 	Subcommands      []*Command
 	UsageFunc        func(*Command) error
 	HelpFunc         func(*Command)
-	FlattenUsageTree bool
+	GroupUsageTree bool
 	cobraCmd         *cobra.Command
 	isSpaceSeparated bool
 }
@@ -107,9 +107,9 @@ func (c *Command) helpFuncWrapper(*cobra.Command, []string) {
 func (c *Command) defaultUsageFunc(*Command) error {
 	// TODO :: Seems like Usage & Help have the same use for us right now. (Perhaps just for default)
 	tmplName := template.DefaultTemplate
-	templateToExecute := template.DefaultUsageTemplateGrouped
-	if c.FlattenUsageTree {
-		templateToExecute = template.DefaultUsageTemplate
+	templateToExecute := template.DefaultUsageTemplate
+	if c.GroupUsageTree {
+		templateToExecute = template.DefaultUsageTemplateGrouped
 	}
 	return template.TryExecuteTemplate(tmplName, template.DefaultTemplate, templateToExecute, template.DefaultTemplateFuncs, c)
 }
@@ -117,9 +117,9 @@ func (c *Command) defaultUsageFunc(*Command) error {
 // defaultHelpFunc is the Help function that will be called if none is provided
 func (c *Command) defaultHelpFunc(*Command) {
 	tmplName := template.DefaultTemplate
-	templateToExecute := template.DefaultHelpTemplateGrouped
-	if c.FlattenUsageTree {
-		templateToExecute = template.DefaultHelpTemplate
+	templateToExecute := template.DefaultHelpTemplate
+	if c.GroupUsageTree {
+		templateToExecute = template.DefaultHelpTemplateGrouped
 	}
 	err := template.TryExecuteTemplate(tmplName, template.DefaultTemplate, templateToExecute, template.DefaultTemplateFuncs, c)
 	if err != nil {

--- a/pkg/util/cli/template/template.go
+++ b/pkg/util/cli/template/template.go
@@ -31,7 +31,7 @@ Type {{.CommandPathBinary}}{{.CommandSeparator}}{{if .HasSubcommands}}{{ colored
 {{define "TemplateBody"}}{{template "Flags" .}}{{ $namePadding := 35 }}
 {{if .HasSubcommands}}
 {{ colored "Subcommands: " "white" }}{{range .AllSubcommands}}
-    {{ colored (rpad .CommandPathBinary $namePadding) "blue" }} {{ colored .Short "gray" }}{{end}}
+    {{ colored (rpad .CommandPathBinary $namePadding) "blue" }}{{.Short}}{{end}}
 {{end}}{{end}}
 
 {{define "TemplateGroupedBody"}}{{template "Flags" .}}{{ $namePadding := 35 }}
@@ -39,7 +39,7 @@ Type {{.CommandPathBinary}}{{.CommandSeparator}}{{if .HasSubcommands}}{{ colored
 {{ colored "Subcommands: " "white" }}
 {{range .SubcommandsByGroup}}
 {{ colored .GroupName "blue" }}: {{range .Commands}}
- {{ colored (rpad .Name $namePadding) "none" }} {{colored .Short "gray"}}{{end}}
+ {{ colored (rpad .Name $namePadding) "none" }}{{.Short}}{{end}}
 {{end}}{{end}}{{end}}
 
 {{define "HelpTemplate"}}{{template "HeaderHelp" .}}{{template "TemplateBody" .}}{{end}}


### PR DESCRIPTION
* Remove use of gray colour which blends into the background on most terminal palettes
* Make grouping subcommands configurable and off by default 