### PR TITLE
initialize ServiceBuild.Sidecars in mock

### DIFF
--- a/pkg/api/server/mock/backend.go
+++ b/pkg/api/server/mock/backend.go
@@ -597,7 +597,6 @@ func (backend *Backend) runBuild(build *v1.Build) {
 		s.StartTimestamp = &now
 		s.ContainerBuild.State = v1.ContainerBuildStateRunning
 		s.ContainerBuild.StartTimestamp = &now
-		s.Sidecars = make(map[string]v1.ContainerBuild)
 		build.Services[sp] = s
 	}
 

--- a/pkg/api/server/mock/backend.go
+++ b/pkg/api/server/mock/backend.go
@@ -574,6 +574,7 @@ func (backend *Backend) newMockBuild(systemID v1.SystemID, v v1.SystemVersion) *
 				ContainerBuild: v1.ContainerBuild{
 					State: v1.ContainerBuildStatePending,
 				},
+				Sidecars: make(map[string]v1.ContainerBuild),
 			},
 		},
 	}
@@ -596,7 +597,7 @@ func (backend *Backend) runBuild(build *v1.Build) {
 		s.StartTimestamp = &now
 		s.ContainerBuild.State = v1.ContainerBuildStateRunning
 		s.ContainerBuild.StartTimestamp = &now
-
+		s.Sidecars = make(map[string]v1.ContainerBuild)
 		build.Services[sp] = s
 	}
 
@@ -617,7 +618,6 @@ func (backend *Backend) finishBuild(build *v1.Build) {
 		s.CompletionTimestamp = &now
 		s.ContainerBuild.CompletionTimestamp = &now
 		s.ContainerBuild.State = v1.ContainerBuildStateSucceeded
-		s.CompletionTimestamp = &now
 		build.Services[sp] = s
 	}
 


### PR DESCRIPTION
https://github.com/mlab-lattice/lattice/blob/ccf20e4c268e29316086685e74d3221adc001346/pkg/backend/kubernetes/api/server/backend/build.go#L274-L278

It looks like the backend api initialises ServiceBuild.Sidecars, whereas this is `null` in the mock. Also removed a duplicate assignment.